### PR TITLE
Use client pagination

### DIFF
--- a/src/components/extractooor/Extractooor.tsx
+++ b/src/components/extractooor/Extractooor.tsx
@@ -329,30 +329,19 @@ function Extractooor() {
     await fetch();
   };
 
-  const tablePagesPerQuery = Math.floor(
-    (query?.getPageSize() || 1000) / tablePageSize
-  );
-  const tableRows = rows.slice(
-    (tablePageNumber % tablePagesPerQuery) * tablePageSize,
-    (tablePageNumber % tablePagesPerQuery) * tablePageSize + tablePageSize
-  );
-
   return (
     <div className="h-full">
       <DataGridPro
-        rows={tableRows}
+        rows={rows}
         columns={columns}
         rowsPerPageOptions={[tablePageSize]}
         rowCount={rows.length}
         getRowClassName={() => 'cursor-pointer'}
         pagination
-        paginationMode="server"
         filterMode="server"
         sortingMode="server"
         loading={loading}
         pageSize={tablePageSize}
-        page={tablePageNumber}
-        onPageChange={setTablePageNumber}
         onPageSizeChange={setTablePageSize}
         onFilterModelChange={handleFilterModelChange}
         onSortModelChange={handleSortModelChange}


### PR DESCRIPTION
This is to allow exporting the rows in all pages when there is more than one page.

With server pagination , the DataGrid component only holds the rows for a single page which doesn't allow exporting all pages. The exporter can only use the rows provided to the component in that case.

With client pagination, all the rows are provided to the component beforehand where there is no dynamic fetch to pull more data when changing pages. The exporter can export all rows in that case.

Anyway, using server pagination seems useless in this case considering that there is no refetch done when changing pages. The same rows are sliced differently to get the pages.