### PR TITLE
Reset the active page back to 0 after filtering or sorting

### DIFF
--- a/src/components/extractooor/Extractooor.tsx
+++ b/src/components/extractooor/Extractooor.tsx
@@ -105,6 +105,7 @@ function Extractooor() {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+  const [page, setPage] = useState<number>(0);
 
   const cancel = async () => {
     setCancelling(true);
@@ -360,6 +361,8 @@ function Extractooor() {
     });
 
     await fetch();
+
+    setPage(0);
   };
 
   const handleSortModelChange = async (model: GridSortModel) => {
@@ -382,6 +385,8 @@ function Extractooor() {
     }
 
     await fetch();
+
+    setPage(0);
   };
 
   return (
@@ -449,6 +454,8 @@ function Extractooor() {
         rowCount={rows.length}
         getRowClassName={() => 'cursor-pointer'}
         pagination
+        onPageChange={(newPage) => setPage(newPage)}
+        page={page}
         filterMode="server"
         sortingMode="server"
         loading={loading}


### PR DESCRIPTION
The active page isn't reset back to 0 after filtering or sorting.

If there is still data at the page where the user did the action of sorting or filtering, the DataGrid will stick to that page.

Considering that the data is reshuffled after filtering or ordering the data, it is probably better to reset the active page back to 0, so the user doesn't have to manually go back to that page to scroll the data.