### PR TITLE
Provide query builders and drop cancelled results to avoid re-render

### DIFF
--- a/src/components/extractooor/Extractooor.tsx
+++ b/src/components/extractooor/Extractooor.tsx
@@ -235,7 +235,7 @@ function Extractooor() {
       setColumns([]);
       setRows([]);
       setCurrentQueryIndex(queryIndex);
-      setQuery(queries[queryIndex]);
+      setQuery(queries[queryIndex] ? queries[queryIndex]!() : undefined);
     }
   };
 
@@ -276,7 +276,7 @@ function Extractooor() {
 
   useEffect(() => {
     if (queries && queries.length > 0) {
-      setQuery(queries[0]);
+      setQuery(queries[0] ? queries[0]!() : undefined);
     } else {
       setLoading(true);
     }
@@ -320,7 +320,7 @@ function Extractooor() {
           >
             {(queries || []).map((q, i) => (
               <MenuItem key={i} value={i}>
-                {q.title}
+                {q().title}
               </MenuItem>
             ))}
           </Select>

--- a/src/shared/Extractooor/Extractooor.type.tsx
+++ b/src/shared/Extractooor/Extractooor.type.tsx
@@ -33,7 +33,7 @@ export interface ExtractooorQuery {
 }
 
 export interface ExtractooorProviderState {
-  queries?: ExtractooorQuery[];
+  queries?: (() => ExtractooorQuery)[];
   fullscreen: boolean;
   setFullscreen: (value: boolean) => void;
 }

--- a/src/shared/Extractooor/Extractooor.type.tsx
+++ b/src/shared/Extractooor/Extractooor.type.tsx
@@ -10,11 +10,17 @@ export type Column = GridColDef & {
   toExcel?: (value: any) => any;
 };
 
+export interface ExtractooorFetchResult {
+  rows: GridRowsProp;
+  columns: Column[];
+  valid: boolean;
+}
+
 export interface ExtractooorQuery {
   readonly title: string;
   readonly description: string;
-  fetchNext(): Promise<{ rows: GridRowsProp; columns: Column[] }>;
-  fetchAll(): Promise<{ rows: GridRowsProp; columns: Column[] }>;
+  fetchNext(): Promise<ExtractooorFetchResult>;
+  fetchAll(): Promise<ExtractooorFetchResult>;
   addFilter(field: string, operator: Operator, value: string | string[]): void;
   removeFilter(field: string): void;
   clearFilters(): void;
@@ -29,7 +35,7 @@ export interface ExtractooorQuery {
   getColumnVisibilityModel(): { [key: string]: boolean } | undefined;
   reset(): void;
   resetBatch(): void;
-  cancel(): void;
+  cancel(): Promise<void>;
 }
 
 export interface ExtractooorProviderState {

--- a/src/shared/Extractooor/ExtractooorProvider.tsx
+++ b/src/shared/Extractooor/ExtractooorProvider.tsx
@@ -55,7 +55,9 @@ export const ExtractoooorProvider: FC<ExtractooorProviderProps> = ({
 }: ExtractooorProviderProps) => {
   const { tokenService, uniswapPoolService, apolloClient } =
     useUniswapV3SubgraphContext();
-  const [queries, setQueries] = useState<ExtractooorQuery[] | undefined>();
+  const [queries, setQueries] = useState<
+    (() => ExtractooorQuery)[] | undefined
+  >();
   const [fullscreen, setFullscreen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -64,32 +66,58 @@ export const ExtractoooorProvider: FC<ExtractooorProviderProps> = ({
         /**
          * Initialize all queries here!
          */
-        new UniswapDayDatasQuery(
-          apolloClient,
-          tokenService,
-          uniswapPoolService
-        ),
-        new SwapsQuery(apolloClient, tokenService, uniswapPoolService),
-        new TokensQuery(apolloClient, tokenService, uniswapPoolService),
-        new PoolsQuery(apolloClient, tokenService, uniswapPoolService),
-        new TicksQuery(apolloClient, tokenService, uniswapPoolService),
-        new PositionsQuery(apolloClient, tokenService, uniswapPoolService),
-        new PositionSnapshotsQuery(
-          apolloClient,
-          tokenService,
-          uniswapPoolService
-        ),
-        new TransactionsQuery(apolloClient, tokenService, uniswapPoolService),
-        new MintsQuery(apolloClient, tokenService, uniswapPoolService),
-        new BurnsQuery(apolloClient, tokenService, uniswapPoolService),
-        new CollectsQuery(apolloClient, tokenService, uniswapPoolService),
-        new FlashesQuery(apolloClient, tokenService, uniswapPoolService),
-        new PoolDayDatasQuery(apolloClient, tokenService, uniswapPoolService),
-        new PoolHourDatasQuery(apolloClient, tokenService, uniswapPoolService),
-        new TickHourDatasQuery(apolloClient, tokenService, uniswapPoolService),
-        new TickDayDatasQuery(apolloClient, tokenService, uniswapPoolService),
-        new TokenDayDatasQuery(apolloClient, tokenService, uniswapPoolService),
-        new TokenHourDatasQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new UniswapDayDatasQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
+        () => new SwapsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new TokensQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new PoolsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new TicksQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new PositionsQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new PositionSnapshotsQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
+        () =>
+          new TransactionsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new MintsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new BurnsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new CollectsQuery(apolloClient, tokenService, uniswapPoolService),
+        () => new FlashesQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new PoolDayDatasQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new PoolHourDatasQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
+        () =>
+          new TickHourDatasQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
+        () =>
+          new TickDayDatasQuery(apolloClient, tokenService, uniswapPoolService),
+        () =>
+          new TokenDayDatasQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
+        () =>
+          new TokenHourDatasQuery(
+            apolloClient,
+            tokenService,
+            uniswapPoolService
+          ),
       ]);
     }
   }, [tokenService]);


### PR DESCRIPTION
This is the first PR to improve the async calls.

Problems that are solved in this PR:

- Allows dropping the results of cancelled queries to avoid unnecessary component rendering. There is a validity bit in the results to confirm the validity of the results. The query caller handles the validity bit where they can decide to not rerender if the results aren't valid (e.g. don' call setRows() if the results aren't valid).
- Provide factories to build the query objects for the different tables instead of providing the object directly. The idea is to rescope the lifetime of the query object to be tied to the lifetime of the underlying query, where the query object is regenerated when updating the query parameters. The factory is used to build the initial query object that can be extended with extra parameters (e.g. filters). Eventually, the query object update could be automatically triggered using a dependency graph built from useEffect hooks.
